### PR TITLE
Add useful payload parameters

### DIFF
--- a/abstractions.py
+++ b/abstractions.py
@@ -11,10 +11,12 @@ class Choice(BaseModel):
 
 
 class Payload(BaseModel):
+    max_time: float = None
     max_tokens: int = 100
     num_return_sequences: int
     one_line: bool = True
     prompt: str
+    repetition_penalty: float = 1.
     temperature: float = 0.1
     top_k: int
     top_p: float


### PR DESCRIPTION
## Initiative
Since I added configurable max_time and repetition_penalty settings to twinny extension in [rjmacarthy/twinny/#7](https://github.com/rjmacarthy/twinny/pull/7), the corresponding parameters should also be synced to the server side.

### Add
Now max_time and repetition_penalty are able to be passed from client side to model generate side.

### Related Issue
[rjmacarthy/twinny/#6](https://github.com/rjmacarthy/twinny/issues/6)